### PR TITLE
Fix method TruncateInBytes to truncate string may raise panic

### DIFF
--- a/notify/util.go
+++ b/notify/util.go
@@ -120,6 +120,12 @@ func TruncateInBytes(s string, n int) (string, bool) {
 	r := []rune(s)
 	truncationTarget := n - 3
 
+	// Notes: if truncationTarget is greater than the capacity of r,
+	// it will raise error that slice bounds out of range.
+	if truncationTarget > cap(r) {
+		truncationTarget = cap(r)
+	}
+
 	// Next, let's truncate the runes to the lower possible number.
 	truncatedRunes := r[:truncationTarget]
 	for len(string(truncatedRunes)) > truncationTarget {


### PR DESCRIPTION
when the truncationTarge is greater than the capacity of the string, the index will be out of bounds when slicing the string
we can test follow:
```go
func test() {
	s := strings.Repeat("啊111111111", 358) // 358 will raise error

	r := []rune(s)
	fmt.Println(cap(r)) // when count is 359, the cap is 4096, when count is 358, the cap is 3584.

	// panic: runtime error: slice bounds out of range [:4093] with capacity 3584
	fmt.Println(TruncateInBytes(s, 4096))
}

func TruncateInBytes(s string, n int) (string, bool) {
	... ...
}
```